### PR TITLE
Add merging method for dictionary

### DIFF
--- a/Sources/Dictionary.swift
+++ b/Sources/Dictionary.swift
@@ -38,4 +38,11 @@ extension Dictionary {
     copy.removeValue(forKey: key)
     return copy
   }
+
+  /// returns a new directory by merging all values for respective keys.
+  public func merging(_ dictionary: Dictionary<Key, Value>) -> Dictionary<Key, Value> {
+    var copy = self
+    dictionary.forEach { copy.updateValue($1, forKey: $0) }
+    return copy
+  }
 }

--- a/Tests/ImmutableTests/DictinoaryTests.swift
+++ b/Tests/ImmutableTests/DictinoaryTests.swift
@@ -54,6 +54,11 @@ class DictionaryTests: XCTestCase {
     XCTAssertEqual(["a": 10].removingValue(forKey: "a"), [:])
   }
 
+  func testMergingValues() {
+    XCTAssertEqual(["a": 10, "b": 20].merging(["b": 30, "c": 40]),
+                   ["a": 10, "b": 30, "c": 40])
+  }
+
 
   static var allTests : [(String, (DictionaryTests) -> () throws -> Void)] {
     return [


### PR DESCRIPTION
Merging `Dictionary` will update or add each value of the receiver for respective keys. This will preserve existing values if parameter does not have a key for the values of the receiver.

eg) `["a": 10, "b": 20].merging(["b": 30, "c": 40])` will be ` ["a": 10, "b": 30, "c": 40]`