### PR TITLE
Add `removingAll(where:)` and `removingFirst(where:)` methods for Collection

### DIFF
--- a/Sources/Immutable/Collection.swift
+++ b/Sources/Immutable/Collection.swift
@@ -56,6 +56,22 @@ extension RangeReplaceableCollection {
     return copy
   }
 
+  /// Returns a new collection by removing all elements that satisfy the given predicate.
+  public func removingAll(where predicate: (Self.Iterator.Element) throws -> Bool) rethrows -> Self {
+    var copy = self
+    try copy.removeAll(where: predicate)
+    return copy
+  }
+
+  /// Returns a new collection by removing first element that satisfies the given predicate.
+  public func removingFirst(where predicate: (Self.Iterator.Element) throws -> Bool) rethrows -> Self {
+    var copy = self
+    if let i = try firstIndex(where: predicate) {
+      copy.remove(at: i)
+    }
+    return copy
+  }
+
   /// Returns a new collection by replacing given subrange with new elements.
   public func replacingSubrange<C>(_ subrange: Range<Self.Index>, with newElements: C) -> Self where C : Collection, C.Iterator.Element == Self.Iterator.Element {
     var copy = self

--- a/Tests/ImmutableTests/CollectionTests.swift
+++ b/Tests/ImmutableTests/CollectionTests.swift
@@ -26,6 +26,8 @@ final class CollectionTests: XCTestCase {
     XCTAssertEqual([1, 2, 3].removingAll(), [])
     XCTAssertEqual([1, 2, 3].removingFirst(), [2, 3])
     XCTAssertEqual([1, 2, 3].removingFirst(2), [3])
+    XCTAssertEqual([1, 2, 3].removingAll(where: { $0 < 3 }), [3])
+    XCTAssertEqual([1, 2, 3].removingFirst(where: { $0 < 3 }), [2, 3])
   }
 
   func testReplacing() {


### PR DESCRIPTION
Support removing with predicate immutably.